### PR TITLE
Add Android specific setup instructions to ballast-debugger.md

### DIFF
--- a/docs/src/orchid/resources/wiki/modules/ballast-debugger.md
+++ b/docs/src/orchid/resources/wiki/modules/ballast-debugger.md
@@ -333,6 +333,31 @@ kotlin {
 }
 ```
 
+### Android
+
+On Android you need to add a clear text traffic permission for `10.0.2.2` to your network security configuration.
+
+To do that you need to create the file `network_security_config.xml` at `src/main/res/xml` in your Android module. The content should look like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>
+```
+
+Then, in your `AndroidManifest.xml` add the following line to your `application` configuration:
+
+```xml
+<application
+  ...
+  android:networkSecurityConfig="@xml/network_security_config" >
+    ...
+</application>
+```
+
 [1]: https://ktor.io/docs/http-client-engines.html
 [2]: https://plugins.jetbrains.com/plugin/18702-ballast/versions
 [3]: https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk

--- a/docs/src/orchid/resources/wiki/modules/ballast-debugger.md
+++ b/docs/src/orchid/resources/wiki/modules/ballast-debugger.md
@@ -86,6 +86,31 @@ class ExampleViewModel(coroutineScope: CoroutineScope) : BasicViewModel<
 )
 ```
 
+## Android
+
+On Android you need to add a clear text traffic permission for `10.0.2.2` to your network security configuration.
+
+To do that you need to create the file `network_security_config.xml` at `src/main/res/xml` in your Android module. The content should look like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>
+```
+
+Then, in your `AndroidManifest.xml` add the following line to your `application` configuration:
+
+```xml
+<application
+  ...
+  android:networkSecurityConfig="@xml/network_security_config" >
+    ...
+</application>
+```
+
 ## State/Input Serialization (v4+)
 
 Since version 4.0.0, the Debugger allows you to send JSON (or other serialized content) from the graphical UI back to 
@@ -331,31 +356,6 @@ kotlin {
         }
     }
 }
-```
-
-### Android
-
-On Android you need to add a clear text traffic permission for `10.0.2.2` to your network security configuration.
-
-To do that you need to create the file `network_security_config.xml` at `src/main/res/xml` in your Android module. The content should look like this:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config xmlns:android="http://schemas.android.com/apk/res/android">
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">10.0.2.2</domain>
-    </domain-config>
-</network-security-config>
-```
-
-Then, in your `AndroidManifest.xml` add the following line to your `application` configuration:
-
-```xml
-<application
-  ...
-  android:networkSecurityConfig="@xml/network_security_config" >
-    ...
-</application>
 ```
 
 [1]: https://ktor.io/docs/http-client-engines.html


### PR DESCRIPTION
On Android, some additional setup steps are needed to get the debugger IDE plugin to work. This PR adds those steps to the docs.